### PR TITLE
docs: fix warning about missing html_static_path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,4 +26,4 @@ language = 'Thomas Bechtold'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'alabaster'
-html_static_path = ['_static']
+# html_static_path = ['_static']


### PR DESCRIPTION
This fixes:

WARNING: html_static_path entry '_static' does not exist

during the documentation build.