### PR TITLE
fix: add enable-patchelf build-attributes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,8 @@ parts:
     override-build: |
       snapcraftctl build
       ln -sf ../usr/bin/python3.10 $SNAPCRAFT_PART_INSTALL/bin/python3
+    build-attributes:
+      - enable-patchelf
     build-packages:
       - rustc
       - cargo


### PR DESCRIPTION
when using the snap on focal it fails with version GLIBC_2.35 not found. adding enable-patchelf ensures the RPATH used is what is bundled in the snap.