### PR TITLE
fix: make initrdless boot setup with PARTUUID optional

### DIFF
--- a/chimg/chroot.py
+++ b/chimg/chroot.py
@@ -408,6 +408,9 @@ class Chroot:
         self._grub_replace_root_with_label()
 
     def _kernel_boot_without_initramfs(self):
+        if not self._ctx.conf["initrdless"]:
+            return
+
         m, _ = run_command(["findmnt", "-n", "-o", "SOURCE", "--target", self._ctx.chroot_path])
         partuuid, _ = run_command(["blkid", "-s", "PARTUUID", "-o", "value", m])
         if partuuid:

--- a/chimg/config.py
+++ b/chimg/config.py
@@ -83,6 +83,7 @@ class Config(BaseModel):
     """
 
     kernel: Optional[str] = Field(description="Optional kernel deb package name", default=None)
+    initrdless: bool = Field(description="Setup initrdless boot if a kernel gets installed", default=True)
     fs: Optional[ConfigFilesystem] = Field(description="Optional filesystem options", default=None)
     ppas: Optional[List[ConfigPPA]] = Field(description="Optional list of PPAs", default=[])
     debs: Optional[List[ConfigDebPackage]] = Field(description="Optional list of debs", default=[])

--- a/chimg/tests/fixtures/config2.yaml
+++ b/chimg/tests/fixtures/config2.yaml
@@ -1,0 +1,3 @@
+---
+kernel: "linux-aws"
+initrdless: false


### PR DESCRIPTION
imagecraft can't deal with the current logic which requires access to the partition table information. But that information is not available during the imagecraft pack step. So make it possible to disable to initrdless boot setup for grub.