### PR TITLE
docs: correct issues link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ This tool can be used to modify Ubuntu based chroot directories.
 Report issues
 =============
 
-Please use https://github.com/toabctl/chimg/issues to report problems or ask
+Please use [issues](https://github.com/canonical/chimg/issues) to report problems or ask
 questions.
 
 License


### PR DESCRIPTION
the issues link was maintained from the original fork. this redirects using more generic text