### PR TITLE
feat: dynamically find chroot binary

### DIFF
--- a/chimg/chroot.py
+++ b/chimg/chroot.py
@@ -14,6 +14,7 @@ import tempfile
 import os
 import glob
 import yaml
+import shutil
 
 from chimg.common import run_command
 from chimg.context import Context
@@ -37,6 +38,16 @@ class SnapInfo:
 class Chroot:
     def __init__(self, ctx: Context):
         self._ctx: Context = ctx
+        # determine chroot binary: use shutil.which and fall back to common locations
+        chroot_bin = shutil.which("chroot")
+        if not chroot_bin:
+            for p in ("/usr/sbin/chroot", "/usr/bin/chroot", "/bin/chroot"):
+                if os.path.exists(p) and os.access(p, os.X_OK):
+                    chroot_bin = p
+                    break
+        if not chroot_bin:
+            raise RuntimeError("chroot binary not found on host.")
+        self._chroot_bin = chroot_bin
 
     def apply(self):
         """
@@ -86,7 +97,7 @@ class Chroot:
             f.seek(0)
             os.chmod(f.name, 0o700)
             f.close()
-            return run_command(["/usr/sbin/chroot", self._ctx.chroot_path, f"/{os.path.basename(f.name)}"])
+            return run_command([self._chroot_bin, self._ctx.chroot_path, f"/{os.path.basename(f.name)}"])
         except Exception:
             logger.exception(f"Error running command: {cmd}")
             raise
@@ -409,7 +420,7 @@ class Chroot:
         """
         run_command(
             [
-                "/usr/sbin/chroot",
+                self._chroot_bin,
                 self._ctx.chroot_path,
                 "apt-get",
                 "install",
@@ -421,7 +432,7 @@ class Chroot:
         )
         if deb.get("hold", False):
             run_command(
-                ["/usr/sbin/chroot", self._ctx.chroot_path, "apt-mark", "hold", deb["name"]],
+                [self._chroot_bin, self._ctx.chroot_path, "apt-mark", "hold", deb["name"]],
                 env={"DEBIAN_FRONTEND": "noninteractive"},
             )
 
@@ -430,7 +441,7 @@ class Chroot:
         Call apt-get update in the chroot
         """
         run_command(
-            ["/usr/sbin/chroot", self._ctx.chroot_path, "apt-get", "update", "--assume-yes", "--error-on=any"],
+            [self._chroot_bin, self._ctx.chroot_path, "apt-get", "update", "--assume-yes", "--error-on=any"],
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
 
@@ -445,7 +456,7 @@ class Chroot:
         logger.info("Installing kernel ...")
         run_command(
             [
-                "/usr/sbin/chroot",
+                self._chroot_bin,
                 self._ctx.chroot_path,
                 "apt-get",
                 "remove",
@@ -460,7 +471,7 @@ class Chroot:
         )
         self._apt_update()
         run_command(
-            ["/usr/sbin/chroot", self._ctx.chroot_path, "apt-get", "install", "--assume-yes", self._ctx.conf["kernel"]],
+            [self._chroot_bin, self._ctx.chroot_path, "apt-get", "install", "--assume-yes", self._ctx.conf["kernel"]],
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
         logger.info("Kernel installed")
@@ -616,7 +627,7 @@ GRUB_FORCE_PARTUUID={partuuid}"""
                         )
                     )
                 logger.info("All PPAs setup")
-                cmd = ["/usr/sbin/chroot", self._ctx.chroot_path, "apt-cache", "policy"]
+                cmd = [self._chroot_bin, self._ctx.chroot_path, "apt-cache", "policy"]
                 out, err = run_command(cmd)
                 logger.info(out)
                 yield

--- a/chimg/tests/functional/test_chroot.py
+++ b/chimg/tests/functional/test_chroot.py
@@ -10,6 +10,8 @@ import subprocess
 from functools import partial
 from chimg import chroot
 from chimg import context
+import shutil
+from typing import cast
 
 
 curdir = pathlib.Path(__file__).parent.resolve()
@@ -33,10 +35,20 @@ def _check_deb_installed(deb_name: str, deb_hold: bool, chroot_path: pathlib.Pat
     """
     check that a given deb package is installed
     """
-    res = subprocess.run(["/usr/sbin/chroot", chroot_path.as_posix(), "dpkg-query", "-W", deb_name])
+    # Resolve chroot binary the same way as the application does (no env var here)
+    chroot_bin = shutil.which("chroot")
+    if not chroot_bin:
+        for p in ("/usr/sbin/chroot", "/usr/bin/chroot", "/bin/chroot"):
+            if os.path.exists(p) and os.access(p, os.X_OK):
+                chroot_bin = p
+                break
+    if not chroot_bin:
+        pytest.skip("no chroot binary found on host")
+    chroot_bin = cast(str, chroot_bin)
+    res = subprocess.run([chroot_bin, chroot_path.as_posix(), "dpkg-query", "-W", deb_name])
     assert res.returncode == 0, f"deb package {deb_name} is not installed"
     # check the hold status
-    res_mark = subprocess.check_output(["/usr/sbin/chroot", chroot_path.as_posix(), "apt-mark", "showhold", deb_name])
+    res_mark = subprocess.check_output([chroot_bin, chroot_path.as_posix(), "apt-mark", "showhold", deb_name])
     assert (deb_name in res_mark.decode().strip()) is deb_hold
 
 

--- a/chimg/tests/test_chroot.py
+++ b/chimg/tests/test_chroot.py
@@ -29,7 +29,7 @@ def test__cmd_run(mock_subprocess, chroot_dir):
     stdout, stderr = cr._cmd_run("ls")
     assert stdout == "stdout"
     mock_subprocess.assert_called_once_with(
-        ["/usr/sbin/chroot", chroot_dir.as_posix(), ANY], cwd=None, env=None, capture_output=True, shell=False
+        [ANY, chroot_dir.as_posix(), ANY], cwd=None, env=None, capture_output=True, shell=False
     )
 
 
@@ -51,7 +51,7 @@ def test__deb_install(mock_subprocess, chroot_dir, deb):
     cr._deb_install(deb)
     mock_subprocess.assert_any_call(
         [
-            "/usr/sbin/chroot",
+            ANY,
             chroot_dir.as_posix(),
             "apt-get",
             "install",
@@ -66,7 +66,7 @@ def test__deb_install(mock_subprocess, chroot_dir, deb):
     )
     if deb.get("hold", False):
         mock_subprocess.assert_any_call(
-            ["/usr/sbin/chroot", chroot_dir.as_posix(), "apt-mark", "hold", deb["name"]],
+            [ANY, chroot_dir.as_posix(), "apt-mark", "hold", deb["name"]],
             cwd=None,
             env={"DEBIAN_FRONTEND": "noninteractive"},
             capture_output=True,


### PR DESCRIPTION
Chroot is no longer located at /usr/sbin/chroot in resolute. Try finding it in the path or in a few known locations instead.